### PR TITLE
ENG-787 now propagating parameters correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.1.5</version>
+        <version>6.1.7</version>
     </parent>
     <version>6.1.0-SNAPSHOT</version>
     <artifactId>entando-k8s-cluster-infrastructure-controller</artifactId>

--- a/src/main/java/org/entando/kubernetes/controller/clusterinfrastructure/EntandoK8SServiceDeployableContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/clusterinfrastructure/EntandoK8SServiceDeployableContainer.java
@@ -31,11 +31,13 @@ import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.database.DatabaseSchemaCreationResult;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
 import org.entando.kubernetes.controller.spi.KubernetesPermission;
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.SpringBootDeployableContainer;
+import org.entando.kubernetes.model.EntandoDeploymentSpec;
 import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
 import org.entando.kubernetes.model.plugin.ExpectedRole;
 
-public class EntandoK8SServiceDeployableContainer implements SpringBootDeployableContainer {
+public class EntandoK8SServiceDeployableContainer implements SpringBootDeployableContainer, ParameterizableContainer {
 
     public static final String K8S_SVC_QUALIFIER = "k8s-svc";
     private static final String ENTANDO_K8S_SERVICE_IMAGE_NAME = "entando/entando-k8s-service";
@@ -134,5 +136,10 @@ public class EntandoK8SServiceDeployableContainer implements SpringBootDeployabl
     @Override
     public Optional<DatabasePopulator> useDatabaseSchemas(Map<String, DatabaseSchemaCreationResult> map) {
         return Optional.empty();
+    }
+
+    @Override
+    public EntandoDeploymentSpec getCustomResourceSpec() {
+        return this.entandoClusterInfrastructure.getSpec();
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/clusterinfrastructure/inprocesstests/DeployEntandoClusterInfrastructureTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/clusterinfrastructure/inprocesstests/DeployEntandoClusterInfrastructureTest.java
@@ -41,6 +41,7 @@ import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPath;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.quarkus.runtime.StartupEvent;
+import java.util.Collections;
 import java.util.Map;
 import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
 import org.entando.kubernetes.controller.KeycloakClientConfig;
@@ -57,6 +58,7 @@ import org.entando.kubernetes.controller.inprocesstest.k8sclientdouble.SimpleK8S
 import org.entando.kubernetes.controller.k8sclient.SimpleK8SClient;
 import org.entando.kubernetes.controller.test.support.FluentTraversals;
 import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructureBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -80,7 +82,12 @@ public class DeployEntandoClusterInfrastructureTest implements InProcessTestUtil
     private static final String MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_SECRET = MY_CLUSTER_INFRASTRUCTURE_K8S_SVC + "-secret";
     private static final String MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_DEPLOYMENT = MY_CLUSTER_INFRASTRUCTURE_K8S_SVC + "-deployment";
     private static final String MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_CONTAINER = MY_CLUSTER_INFRASTRUCTURE_K8S_SVC + "-container";
-    private final EntandoClusterInfrastructure entandoClusterInfrastructure = newEntandoClusterInfrastructure();
+    public static final String PARAMETER_VALUE = "MY_VALUE";
+    public static final String PARAMETER_NAME = "MY_PARAM";
+    private final EntandoClusterInfrastructure entandoClusterInfrastructure = new EntandoClusterInfrastructureBuilder(
+            newEntandoClusterInfrastructure()).editSpec().withParameters(Collections.singletonMap(PARAMETER_NAME, PARAMETER_VALUE))
+            .endSpec().build();
+
     @Spy
     private final SimpleK8SClient<EntandoResourceClientDouble> client = new SimpleK8SClientDouble();
     @Mock
@@ -256,6 +263,7 @@ public class DeployEntandoClusterInfrastructureTest implements InProcessTestUtil
         verifyKeycloakSettings(thePrimaryContainerOn(resultingDeployment), MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_SECRET);
         verifySpringSecuritySettings(thePrimaryContainerOn(resultingDeployment), MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_SECRET);
         assertThat(theVariableNamed("SERVER_SERVLET_CONTEXT_PATH").on(thePrimaryContainerOn(resultingDeployment)), is(K8S));
+        assertThat(theVariableNamed(PARAMETER_NAME).on(thePrimaryContainerOn(resultingDeployment)), is(PARAMETER_VALUE));
 
         //And the Deployment state was reloaded from K8S
         verify(client.deployments())


### PR DESCRIPTION
Currently the spec.parameters don't get propagated to all containers. This PR ensures that all containers can now receive environment variables from spec.parameters