### PR TITLE
ENG-3515 use networking.k8s.io/v1 api group instead of extensions/v1b…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,5 +1,5 @@
 #FROM entando/entando-ubi8-java11-base:6.3.0
-FROM entando/entando-k8s-operator-common:6.3.19
+FROM entando/entando-k8s-operator-common:6.5.0-ENG-3515-PR-104
 ARG VERSION
 LABEL name="Entando K8S Cluster Infrastructure Controller" \
       vendor="Entando" \

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.3.18</version>
+        <version>6.5.0-ENG-3515-PR-26</version>
         <relativePath/>
     </parent>
     <version>6.5.0</version>
@@ -65,7 +65,7 @@
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
         <skipLicenseDownload>true</skipLicenseDownload>
-        <entando-k8s-operator-common.version>6.3.19</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>6.5.0-ENG-3515-PR-104</entando-k8s-operator-common.version>
         <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
         <postDeploymentTestGroups>post-deployment</postDeploymentTestGroups>
     </properties>

--- a/src/main/java/org/entando/kubernetes/controller/clusterinfrastructure/ClusterInfrastructureDeploymentResult.java
+++ b/src/main/java/org/entando/kubernetes/controller/clusterinfrastructure/ClusterInfrastructureDeploymentResult.java
@@ -2,7 +2,7 @@ package org.entando.kubernetes.controller.clusterinfrastructure;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.entando.kubernetes.controller.spi.result.ExposedDeploymentResult;
 
 public class ClusterInfrastructureDeploymentResult  extends ExposedDeploymentResult<ClusterInfrastructureDeploymentResult> {

--- a/src/main/java/org/entando/kubernetes/controller/clusterinfrastructure/InfrastructureDeployableBase.java
+++ b/src/main/java/org/entando/kubernetes/controller/clusterinfrastructure/InfrastructureDeployableBase.java
@@ -19,7 +19,7 @@ package org.entando.kubernetes.controller.clusterinfrastructure;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.entando.kubernetes.controller.spi.common.NameUtils;
 import org.entando.kubernetes.controller.support.spibase.IngressingDeployableBase;
 import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;

--- a/src/test/java/org/entando/kubernetes/controller/clusterinfrastructure/inprocesstests/DeployEntandoClusterInfrastructureTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/clusterinfrastructure/inprocesstests/DeployEntandoClusterInfrastructureTest.java
@@ -38,7 +38,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceStatus;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.quarkus.runtime.StartupEvent;
 import java.util.Collections;
@@ -212,8 +212,8 @@ class DeployEntandoClusterInfrastructureTest implements InProcessTestUtil, Fluen
         //With a path that reflects webcontext of the EntandoK8sSvc
         theHttpPath(K8S).on(resultingIngress);
         //that is mapped to the previously created HTTP service
-        assertThat(theBackendFor(K8S).on(resultingIngress).getServicePort().getIntVal(), is(PORT_8084));
-        assertThat(theBackendFor(K8S).on(resultingIngress).getServiceName(), is(MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_SERVICE));
+        assertThat(theBackendFor(K8S).on(resultingIngress).getService().getPort().getNumber(), is(PORT_8084));
+        assertThat(theBackendFor(K8S).on(resultingIngress).getService().getName(), is(MY_CLUSTER_INFRASTRUCTURE_K8S_SVC_SERVICE));
     }
 
     @Test


### PR DESCRIPTION
…eta1 for the created ingresses